### PR TITLE
Read `GH_TOKEN` from context by default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,8 @@ description: 'Add LAPRAS Card to your GitHub profile.'
 author: 'kawamataryo'
 inputs:
   GH_TOKEN:
-    required: true
+    default: ${{ github.token }}
+    required: false
     description: 'GitHub Token'
   SHARE_ID:
     required: true


### PR DESCRIPTION
(This is a kinda feature request so feel free to reject if you don't like!)
GHA provides the token via context: https://docs.github.com/en/actions/security-guides/automatic-token-authentication
With this change, the action now reads it from context and users no longer need to set it explicitly.

Example run: https://github.com/JohnTitor/JohnTitor/actions/runs/3689615309

Signed-off-by: Yuki Okushi <jtitor@2k36.org>